### PR TITLE
Fixed non-fontawesome mobilemenu icon and organized js and css

### DIFF
--- a/config.codekit
+++ b/config.codekit
@@ -13,6 +13,17 @@
 		"outputPathIsSetByUser": 0,
 		"processed": 0
 		},
+	"\/bones-macbook-pro.png": {
+		"fileType": 32768,
+		"ignore": 0,
+		"ignoreWasSetByUser": 0,
+		"initialSize": 44925,
+		"inputAbbreviatedPath": "\/bones-macbook-pro.png",
+		"outputAbbreviatedPath": "\/bones-macbook-pro.png",
+		"outputPathIsOutsideProject": 0,
+		"outputPathIsSetByUser": 0,
+		"processed": 0
+		},
 	"\/bones.php": {
 		"fileType": 8192,
 		"ignore": 0,
@@ -4414,6 +4425,17 @@
 		"initialSize": 19447,
 		"inputAbbreviatedPath": "\/thumbnail.jpg",
 		"outputAbbreviatedPath": "\/thumbnail.jpg",
+		"outputPathIsOutsideProject": 0,
+		"outputPathIsSetByUser": 0,
+		"processed": 0
+		},
+	"\/zurb-foundation-macbook.png": {
+		"fileType": 32768,
+		"ignore": 0,
+		"ignoreWasSetByUser": 0,
+		"initialSize": 35338,
+		"inputAbbreviatedPath": "\/zurb-foundation-macbook.png",
+		"outputAbbreviatedPath": "\/zurb-foundation-macbook.png",
 		"outputPathIsOutsideProject": 0,
 		"outputPathIsSetByUser": 0,
 		"processed": 0

--- a/css/bones.css
+++ b/css/bones.css
@@ -122,6 +122,16 @@ ol {
   font-size: 2rem;
   margin: 0.7rem 0; }
 
+/* Mobilemenu Icon substitute when FontAwesome is disabled */
+.sg-mobilemenu-icon {
+  font-family: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
+  font-size: 1.2rem;
+  text-decoration: none;
+  letter-spacing: 0;
+  line-height: 36px;
+  margin: 6px;
+  padding: 0; }
+
 /* END SmartGravity Mainmenu Navigation */
 /* BEGIN SmartGravity IN PAGE NAVIGATION */
 .top-bar#sg-in-page-navigation, .top-bar#sg-in-page-navigation ul {
@@ -489,9 +499,9 @@ blockquote > blockquote > blockquote {
 #sg-mainmenu .menu > li.active > a, #sg-mainmenu-mobile .menu > li.active > a {
   background-color: #f6f6f6; }
 
-.mobile-nav-toggle {
+.mobile-nav-toggle, .sg-mobilemenu-icon {
   color: #1E8CC7; }
-  .mobile-nav-toggle:hover {
+  .mobile-nav-toggle:hover, .sg-mobilemenu-icon:hover {
     color: #54b3e5; }
 
 /* END SmartGravity Mainmenu Navigation */

--- a/scss/bones/_bones.scss
+++ b/scss/bones/_bones.scss
@@ -121,6 +121,16 @@
     margin: 0.7rem 0;
   }
 }
+/* Mobilemenu Icon substitute when FontAwesome is disabled */
+.sg-mobilemenu-icon {
+  font-family: $body-font-family;
+  font-size: 1.2rem;
+  text-decoration: none;
+  letter-spacing: 0;
+  line-height: 36px;
+  margin: 6px;
+  padding: 0;
+}
 /* END SmartGravity Mainmenu Navigation */
 
 /* BEGIN SmartGravity IN PAGE NAVIGATION */

--- a/scss/bones/_colors.scss
+++ b/scss/bones/_colors.scss
@@ -28,7 +28,7 @@
     }
   }
 }
-.mobile-nav-toggle {
+.mobile-nav-toggle, .sg-mobilemenu-icon {
   color: $primary-color;
   &:hover {
     color: scale-color($primary-color, $lightness: 30%);

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -10,7 +10,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="icon" type="image/png" href="{{ url('theme://images/favicon.png', true) }}" />
     <link rel="canonical" href="{{ page.url(true, true) }}" />
-    {% include 'partials/css.html.twig' %}
+    {% block stylesheets %}
+        {% include 'partials/css.html.twig' %}
+        {% if theme_config.css_bones.enabled %}
+            {% do assets.addCss('theme://css/bones.css',110) %}
+        {% endif %}
+        {% if theme_config.css_custom.enabled %}
+            {% do assets.addCss('theme://css/custom.css',10) %}
+        {% endif %}
+        {% if page.header.fontawesome == "disabled" %}
+        {% elseif page.header.fontawesome == "enabled" or theme_config.fontawesome.enabled %}
+            {% do assets.addCss('theme://css/font-awesome.min.css',115) %}
+        {% endif %}
+        {% if theme_config.google_fonts_logo.enabled %}
+            {% do assets.addCss('//fonts.googleapis.com/css?family=Special+Elite',105) %}
+        {% endif %}
+    {% endblock %}
     {{ assets.css() }}
     {% do assets.addJs('jquery',109) %}
     {{ assets.js() }}
@@ -93,7 +108,14 @@
         {% endblock %}
 
         {% block bottom %}
-            {% include 'partials/js.html.twig' %}
+            {% block javascripts %}
+                {% include 'partials/js.html.twig' %}
+                {% do assets.addJs('theme://bower_components/what-input/what-input.js',{'priority':105, 'group':'bottom'}) %}
+                {% if page.header.google_prettify == "disabled" %}
+                {% elseif page.header.google_prettify == "enabled" or theme_config.google_prettify.enabled %}
+                    {% do assets.addJs('https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js',{'priority':100, 'group':'bottom'}) %}
+                {% endif %}
+            {% endblock %}
             {{ assets.js('bottom') }}
         {% endblock %}
         </div>

--- a/templates/partials/css.html.twig
+++ b/templates/partials/css.html.twig
@@ -1,127 +1,110 @@
-{% block stylesheets %}
-    {% if theme_config.css_global_styles.enabled %}
-        {% do assets.addCss('theme://css/global-styles.css',150) %}
-    {% endif %}
-    {% if theme_config.css_grid.enabled %}
-        {% do assets.addCss('theme://css/grid.css',149) %}
-    		{% elseif theme_config.css_flex_grid.enabled %}
-        {% do assets.addCss('theme://css/flex-grid.css',149) %}
-    {% endif %}
-    {% if theme_config.css_typography.enabled %}
-        {% do assets.addCss('theme://css/typography.css',148) %}
-    {% endif %}
-    {% if theme_config.css_button.enabled %}
-        {% do assets.addCss('theme://css/button.css',147) %}
-    {% endif %}
-    {% if theme_config.css_forms.enabled %}
-        {% do assets.addCss('theme://css/forms.css',146) %}
-    {% endif %}
-    {% if theme_config.css_visibility_classes.enabled %}
-        {% do assets.addCss('theme://css/visibility-classes.css',145) %}
-    {% endif %}
-    {% if theme_config.css_float_classes.enabled %}
-        {% do assets.addCss('theme://css/float-classes.css',144) %}
-    {% endif %}
-    {% if theme_config.css_accordion.enabled %}
-        {% do assets.addCss('theme://css/accordion.css',143) %}
-    {% endif %}
-    {% if theme_config.css_accordion_menu.enabled %}
-        {% do assets.addCss('theme://css/accordion-menu.css',142) %}
-    {% endif %}
-    {% if theme_config.css_badge.enabled %}
-        {% do assets.addCss('theme://css/badge.css',141) %}
-    {% endif %}
-    {% if theme_config.css_breadcrumbs.enabled %}
-        {% do assets.addCss('theme://css/breadcrumbs.css',140) %}
-    {% endif %}
-    {% if theme_config.css_button_group.enabled %}
-        {% do assets.addCss('theme://css/button-group.css',139) %}
-    {% endif %}
-    {% if theme_config.css_callout.enabled %}
-        {% do assets.addCss('theme://css/callout.css',138) %}
-    {% endif %}
-    {% if theme_config.css_close_button.enabled %}
-        {% do assets.addCss('theme://css/close-button.css',137) %}
-    {% endif %}
-    {% if theme_config.css_drilldown_menu.enabled %}
-        {% do assets.addCss('theme://css/drilldown-menu.css',136) %}
-    {% endif %}
-    {% if theme_config.css_dropdown.enabled %}
-        {% do assets.addCss('theme://css/dropdown.css',135) %}
-    {% endif %}
-    {% if theme_config.css_dropdown_menu.enabled %}
-        {% do assets.addCss('theme://css/dropdown-menu.css',134) %}
-    {% endif %}
-    {% if theme_config.css_flex_video.enabled %}
-        {% do assets.addCss('theme://css/flex-video.css',133) %}
-    {% endif %}
-    {% if theme_config.css_label.enabled %}
-        {% do assets.addCss('theme://css/label.css',132) %}
-    {% endif %}
-    {% if theme_config.css_media_object.enabled %}
-        {% do assets.addCss('theme://css/media-object.css',131) %}
-    {% endif %}
-    {% if theme_config.css_menu.enabled %}
-        {% do assets.addCss('theme://css/menu.css',130) %}
-    {% endif %}
-    {% if theme_config.css_off_canvas.enabled %}
-        {% do assets.addCss('theme://css/off-canvas.css',129) %}
-    {% endif %}
-    {% if theme_config.css_orbit.enabled %}
-        {% do assets.addCss('theme://css/orbit.css',128) %}
-    {% endif %}
-    {% if theme_config.css_pagination.enabled %}
-        {% do assets.addCss('theme://css/pagination.css',127) %}
-    {% endif %}
-    {% if theme_config.css_progress_bar.enabled %}
-        {% do assets.addCss('theme://css/progress-bar.css',126) %}
-    {% endif %}
-    {% if theme_config.css_slider.enabled %}
-        {% do assets.addCss('theme://css/slider.css',125) %}
-    {% endif %}
-    {% if theme_config.css_sticky.enabled %}
-        {% do assets.addCss('theme://css/sticky.css',124) %}
-    {% endif %}
-    {% if theme_config.css_reveal.enabled %}
-        {% do assets.addCss('theme://css/reveal.css',123) %}
-    {% endif %}
-    {% if theme_config.css_switch.enabled %}
-        {% do assets.addCss('theme://css/switch.css',122) %}
-    {% endif %}
-    {% if theme_config.css_table.enabled %}
-        {% do assets.addCss('theme://css/table.css',121) %}
-    {% endif %}
-    {% if theme_config.css_tabs.enabled %}
-        {% do assets.addCss('theme://css/tabs.css',120) %}
-    {% endif %}
-    {% if theme_config.css_thumbnail.enabled %}
-        {% do assets.addCss('theme://css/thumbnail.css',119) %}
-    {% endif %}
-    {% if theme_config.css_title_bar.enabled %}
-        {% do assets.addCss('theme://css/title-bar.css',118) %}
-    {% endif %}
-    {% if theme_config.css_tooltip.enabled %}
-        {% do assets.addCss('theme://css/tooltip.css',117) %}
-    {% endif %}
-    {% if theme_config.css_top_bar.enabled %}
-        {% do assets.addCss('theme://css/top-bar.css',116) %}
-    {% endif %}
-    {% if theme_config.css_ui_transitions.enabled %}
-        {% do assets.addCss('theme://css/ui-transitions.css',115) %}
-    {% endif %}
-
-    {% if theme_config.css_bones.enabled %}
-        {% do assets.addCss('theme://css/bones.css',110) %}
-    {% endif %}
-	{% if theme_config.css_custom.enabled %}
-        {% do assets.addCss('theme://css/custom.css',10) %}
-    {% endif %}
-
-    {% if page.header.fontawesome == "disabled" %}
-    {% elseif page.header.fontawesome == "enabled" or theme_config.fontawesome.enabled %}
-        {% do assets.addCss('theme://css/font-awesome.min.css',115) %}
-    {% endif %}
-    {% if theme_config.google_fonts_logo.enabled %}
-        {% do assets.addCss('//fonts.googleapis.com/css?family=Special+Elite',105) %}
-    {% endif %}
-{% endblock %}
+{% if theme_config.css_global_styles.enabled %}
+    {% do assets.addCss('theme://css/global-styles.css',150) %}
+{% endif %}
+{% if theme_config.css_grid.enabled %}
+    {% do assets.addCss('theme://css/grid.css',149) %}
+		{% elseif theme_config.css_flex_grid.enabled %}
+    {% do assets.addCss('theme://css/flex-grid.css',149) %}
+{% endif %}
+{% if theme_config.css_typography.enabled %}
+    {% do assets.addCss('theme://css/typography.css',148) %}
+{% endif %}
+{% if theme_config.css_button.enabled %}
+    {% do assets.addCss('theme://css/button.css',147) %}
+{% endif %}
+{% if theme_config.css_forms.enabled %}
+    {% do assets.addCss('theme://css/forms.css',146) %}
+{% endif %}
+{% if theme_config.css_visibility_classes.enabled %}
+    {% do assets.addCss('theme://css/visibility-classes.css',145) %}
+{% endif %}
+{% if theme_config.css_float_classes.enabled %}
+    {% do assets.addCss('theme://css/float-classes.css',144) %}
+{% endif %}
+{% if theme_config.css_accordion.enabled %}
+    {% do assets.addCss('theme://css/accordion.css',143) %}
+{% endif %}
+{% if theme_config.css_accordion_menu.enabled %}
+    {% do assets.addCss('theme://css/accordion-menu.css',142) %}
+{% endif %}
+{% if theme_config.css_badge.enabled %}
+    {% do assets.addCss('theme://css/badge.css',141) %}
+{% endif %}
+{% if theme_config.css_breadcrumbs.enabled %}
+    {% do assets.addCss('theme://css/breadcrumbs.css',140) %}
+{% endif %}
+{% if theme_config.css_button_group.enabled %}
+    {% do assets.addCss('theme://css/button-group.css',139) %}
+{% endif %}
+{% if theme_config.css_callout.enabled %}
+    {% do assets.addCss('theme://css/callout.css',138) %}
+{% endif %}
+{% if theme_config.css_close_button.enabled %}
+    {% do assets.addCss('theme://css/close-button.css',137) %}
+{% endif %}
+{% if theme_config.css_drilldown_menu.enabled %}
+    {% do assets.addCss('theme://css/drilldown-menu.css',136) %}
+{% endif %}
+{% if theme_config.css_dropdown.enabled %}
+    {% do assets.addCss('theme://css/dropdown.css',135) %}
+{% endif %}
+{% if theme_config.css_dropdown_menu.enabled %}
+    {% do assets.addCss('theme://css/dropdown-menu.css',134) %}
+{% endif %}
+{% if theme_config.css_flex_video.enabled %}
+    {% do assets.addCss('theme://css/flex-video.css',133) %}
+{% endif %}
+{% if theme_config.css_label.enabled %}
+    {% do assets.addCss('theme://css/label.css',132) %}
+{% endif %}
+{% if theme_config.css_media_object.enabled %}
+    {% do assets.addCss('theme://css/media-object.css',131) %}
+{% endif %}
+{% if theme_config.css_menu.enabled %}
+    {% do assets.addCss('theme://css/menu.css',130) %}
+{% endif %}
+{% if theme_config.css_off_canvas.enabled %}
+    {% do assets.addCss('theme://css/off-canvas.css',129) %}
+{% endif %}
+{% if theme_config.css_orbit.enabled %}
+    {% do assets.addCss('theme://css/orbit.css',128) %}
+{% endif %}
+{% if theme_config.css_pagination.enabled %}
+    {% do assets.addCss('theme://css/pagination.css',127) %}
+{% endif %}
+{% if theme_config.css_progress_bar.enabled %}
+    {% do assets.addCss('theme://css/progress-bar.css',126) %}
+{% endif %}
+{% if theme_config.css_slider.enabled %}
+    {% do assets.addCss('theme://css/slider.css',125) %}
+{% endif %}
+{% if theme_config.css_sticky.enabled %}
+    {% do assets.addCss('theme://css/sticky.css',124) %}
+{% endif %}
+{% if theme_config.css_reveal.enabled %}
+    {% do assets.addCss('theme://css/reveal.css',123) %}
+{% endif %}
+{% if theme_config.css_switch.enabled %}
+    {% do assets.addCss('theme://css/switch.css',122) %}
+{% endif %}
+{% if theme_config.css_table.enabled %}
+    {% do assets.addCss('theme://css/table.css',121) %}
+{% endif %}
+{% if theme_config.css_tabs.enabled %}
+    {% do assets.addCss('theme://css/tabs.css',120) %}
+{% endif %}
+{% if theme_config.css_thumbnail.enabled %}
+    {% do assets.addCss('theme://css/thumbnail.css',119) %}
+{% endif %}
+{% if theme_config.css_title_bar.enabled %}
+    {% do assets.addCss('theme://css/title-bar.css',118) %}
+{% endif %}
+{% if theme_config.css_tooltip.enabled %}
+    {% do assets.addCss('theme://css/tooltip.css',117) %}
+{% endif %}
+{% if theme_config.css_top_bar.enabled %}
+    {% do assets.addCss('theme://css/top-bar.css',116) %}
+{% endif %}
+{% if theme_config.css_ui_transitions.enabled %}
+    {% do assets.addCss('theme://css/ui-transitions.css',115) %}
+{% endif %}

--- a/templates/partials/js.html.twig
+++ b/templates/partials/js.html.twig
@@ -1,118 +1,110 @@
-{% block javascripts %}
-    {% do assets.addJs('theme://bower_components/what-input/what-input.js',{'priority':105, 'group':'bottom'}) %}
-    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.core.js',{'priority':104, 'group':'bottom'}) %}
-    
-    {% if page.header.foundation_abide_js == "disabled" %}
-    {% elseif page.header.foundation_abide_js == "enabled" or theme_config.foundation_abide_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.abide.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_accoridion_js == "disabled" %}
-    {% elseif page.header.foundation_accoridion_js == "enabled" or theme_config.foundation_accoridion_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.accoridion.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_accordionMenu_js == "disabled" %}
-    {% elseif page.header.foundation_accordionMenu_js == "enabled" or theme_config.foundation_accordionMenu_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.accordionMenu.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_drilldown_js == "disabled" %}
-    {% elseif page.header.foundation_drilldown_js == "enabled" or theme_config.foundation_drilldown_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.drilldown.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_dropdown_js == "disabled" %}
-    {% elseif page.header.foundation_dropdown_js == "enabled" or theme_config.foundation_dropdown_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.dropdown.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_dropdownMenu_js == "disabled" %}
-    {% elseif page.header.foundation_dropdownMenu_js == "enabled" or theme_config.foundation_dropdownMenu_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.dropdownMenu.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_equalizer_js == "disabled" %}
-    {% elseif page.header.foundation_equalizer_js == "enabled" or theme_config.foundation_equalizer_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.equalizer.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_interchange_js == "disabled" %}
-    {% elseif page.header.foundation_interchange_js == "enabled" or theme_config.foundation_interchange_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.interchange.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_magellan_js == "disabled" %}
-    {% elseif page.header.foundation_magellan_js == "enabled" or theme_config.foundation_magellan_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.magellan.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_offcanvas_js == "disabled" %}
-    {% elseif page.header.foundation_offcanvas_js == "enabled" or theme_config.foundation_offcanvas_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.offcanvas.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_orbit_js == "disabled" %}
-    {% elseif page.header.foundation_orbit_js == "enabled" or theme_config.foundation_orbit_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.orbit.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_responsiveMenu_js == "disabled" %}
-    {% elseif page.header.foundation_responsiveMenu_js == "enabled" or theme_config.foundation_responsiveMenu_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.responsiveMenu.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_responsiveToggle_js == "disabled" %}
-    {% elseif page.header.foundation_responsiveToggle_js == "enabled" or theme_config.foundation_responsiveToggle_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.responsiveToggle.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_reveal_js == "disabled" %}
-    {% elseif page.header.foundation_reveal_js == "enabled" or theme_config.foundation_reveal_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.reveal.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_slider_js == "disabled" %}
-    {% elseif page.header.foundation_slider_js == "enabled" or theme_config.foundation_slider_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.slider.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_sticky_js == "disabled" %}
-    {% elseif page.header.foundation_sticky_js == "enabled" or theme_config.foundation_sticky_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.sticky.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_tabs_js == "disabled" %}
-    {% elseif page.header.foundation_tabs_js == "enabled" or theme_config.foundation_tabs_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.tabs.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_toggler_js == "disabled" %}
-    {% elseif page.header.foundation_toggler_js == "enabled" or theme_config.foundation_toggler_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.toggler.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_tooltip_js == "disabled" %}
-    {% elseif page.header.foundation_tooltip_js == "enabled" or theme_config.foundation_tooltip_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.tooltip.js',{'priority':103, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_box_js == "disabled" %}
-    {% elseif page.header.foundation_util_box_js == "enabled" or theme_config.foundation_util_box_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.box.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_keyboard_js == "disabled" %}
-    {% elseif page.header.foundation_util_keyboard_js == "enabled" or theme_config.foundation_util_keyboard_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.keyboard.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_mediaQuery_js == "disabled" %}
-    {% elseif page.header.foundation_util_mediaQuery_js == "enabled" or theme_config.foundation_util_mediaQuery_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.mediaQuery.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_motion_js == "disabled" %}
-    {% elseif page.header.foundation_util_motion_js == "enabled" or theme_config.foundation_util_motion_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.motion.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_nest_js == "disabled" %}
-    {% elseif page.header.foundation_nest_util_js == "enabled" or theme_config.foundation_util_nest_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.nest.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_timerAndImageLoader_js == "disabled" %}
-    {% elseif page.header.foundation_util_timerAndImageLoader_js == "enabled" or theme_config.foundation_util_timerAndImageLoader_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.timerAndImageLoader.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_touch_js == "disabled" %}
-    {% elseif page.header.foundation_util_touch_js == "enabled" or theme_config.foundation_util_touch_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.touch.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.foundation_util_triggers_js == "disabled" %}
-    {% elseif page.header.foundation_util_triggers_js == "enabled" or theme_config.foundation_util_triggers_js.enabled %}
-        {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.triggers.js',{'priority':102, 'group':'bottom'}) %}
-    {% endif %}
-    {% if page.header.google_prettify == "disabled" %}
-    {% elseif page.header.google_prettify == "enabled" or theme_config.google_prettify.enabled %}
-        {% do assets.addJs('https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js',{'priority':100, 'group':'bottom'}) %}
-    {% endif %}
-    {% do assets.addInlineJs('$(document).foundation();',{'priority':99, 'pipeline':false, 'group':'bottom'}) %}
-{% endblock %}
+{% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.core.js',{'priority':104, 'group':'bottom'}) %}
+{% if page.header.foundation_abide_js == "disabled" %}
+{% elseif page.header.foundation_abide_js == "enabled" or theme_config.foundation_abide_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.abide.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_accoridion_js == "disabled" %}
+{% elseif page.header.foundation_accoridion_js == "enabled" or theme_config.foundation_accoridion_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.accoridion.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_accordionMenu_js == "disabled" %}
+{% elseif page.header.foundation_accordionMenu_js == "enabled" or theme_config.foundation_accordionMenu_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.accordionMenu.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_drilldown_js == "disabled" %}
+{% elseif page.header.foundation_drilldown_js == "enabled" or theme_config.foundation_drilldown_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.drilldown.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_dropdown_js == "disabled" %}
+{% elseif page.header.foundation_dropdown_js == "enabled" or theme_config.foundation_dropdown_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.dropdown.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_dropdownMenu_js == "disabled" %}
+{% elseif page.header.foundation_dropdownMenu_js == "enabled" or theme_config.foundation_dropdownMenu_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.dropdownMenu.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_equalizer_js == "disabled" %}
+{% elseif page.header.foundation_equalizer_js == "enabled" or theme_config.foundation_equalizer_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.equalizer.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_interchange_js == "disabled" %}
+{% elseif page.header.foundation_interchange_js == "enabled" or theme_config.foundation_interchange_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.interchange.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_magellan_js == "disabled" %}
+{% elseif page.header.foundation_magellan_js == "enabled" or theme_config.foundation_magellan_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.magellan.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_offcanvas_js == "disabled" %}
+{% elseif page.header.foundation_offcanvas_js == "enabled" or theme_config.foundation_offcanvas_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.offcanvas.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_orbit_js == "disabled" %}
+{% elseif page.header.foundation_orbit_js == "enabled" or theme_config.foundation_orbit_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.orbit.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_responsiveMenu_js == "disabled" %}
+{% elseif page.header.foundation_responsiveMenu_js == "enabled" or theme_config.foundation_responsiveMenu_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.responsiveMenu.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_responsiveToggle_js == "disabled" %}
+{% elseif page.header.foundation_responsiveToggle_js == "enabled" or theme_config.foundation_responsiveToggle_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.responsiveToggle.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_reveal_js == "disabled" %}
+{% elseif page.header.foundation_reveal_js == "enabled" or theme_config.foundation_reveal_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.reveal.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_slider_js == "disabled" %}
+{% elseif page.header.foundation_slider_js == "enabled" or theme_config.foundation_slider_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.slider.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_sticky_js == "disabled" %}
+{% elseif page.header.foundation_sticky_js == "enabled" or theme_config.foundation_sticky_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.sticky.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_tabs_js == "disabled" %}
+{% elseif page.header.foundation_tabs_js == "enabled" or theme_config.foundation_tabs_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.tabs.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_toggler_js == "disabled" %}
+{% elseif page.header.foundation_toggler_js == "enabled" or theme_config.foundation_toggler_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.toggler.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_tooltip_js == "disabled" %}
+{% elseif page.header.foundation_tooltip_js == "enabled" or theme_config.foundation_tooltip_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.tooltip.js',{'priority':103, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_box_js == "disabled" %}
+{% elseif page.header.foundation_util_box_js == "enabled" or theme_config.foundation_util_box_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.box.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_keyboard_js == "disabled" %}
+{% elseif page.header.foundation_util_keyboard_js == "enabled" or theme_config.foundation_util_keyboard_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.keyboard.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_mediaQuery_js == "disabled" %}
+{% elseif page.header.foundation_util_mediaQuery_js == "enabled" or theme_config.foundation_util_mediaQuery_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.mediaQuery.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_motion_js == "disabled" %}
+{% elseif page.header.foundation_util_motion_js == "enabled" or theme_config.foundation_util_motion_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.motion.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_nest_js == "disabled" %}
+{% elseif page.header.foundation_nest_util_js == "enabled" or theme_config.foundation_util_nest_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.nest.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_timerAndImageLoader_js == "disabled" %}
+{% elseif page.header.foundation_util_timerAndImageLoader_js == "enabled" or theme_config.foundation_util_timerAndImageLoader_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.timerAndImageLoader.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_touch_js == "disabled" %}
+{% elseif page.header.foundation_util_touch_js == "enabled" or theme_config.foundation_util_touch_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.touch.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% if page.header.foundation_util_triggers_js == "disabled" %}
+{% elseif page.header.foundation_util_triggers_js == "enabled" or theme_config.foundation_util_triggers_js.enabled %}
+    {% do assets.addJs('theme://bower_components/foundation-sites/js/foundation.util.triggers.js',{'priority':102, 'group':'bottom'}) %}
+{% endif %}
+{% do assets.addInlineJs('$(document).foundation();',{'priority':99, 'pipeline':false, 'group':'bottom'}) %}


### PR DESCRIPTION
Fixed non-fontawesome mobilemenu icon styling and now only foundation js and css are in the individual twig files.
