### PR TITLE
Remove unneeded streams from Theme YAML

### DIFF
--- a/bones.yaml
+++ b/bones.yaml
@@ -48,10 +48,3 @@ css_sticky:
   enabled: true
 css_table:
   enabled: true
-
-streams:
-  schemes:
-    theme:
-      type: ReadOnlyStream
-      paths:
-        - user/themes/bones


### PR DESCRIPTION
These lines were in Antimatter and other themes, but they are useless now and break multisite
