### PR TITLE
fixed URL for code-prettify

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -128,7 +128,7 @@
                 {% endif %}
                 {% if page.header.google_prettify == "disabled" %}
                 {% elseif page.header.google_prettify == "enabled" or theme_config.google_prettify.enabled %}
-                    {% do assets.addJs('https://github.com/google/code-prettify',{'priority':100, 'group':'bottom'}) %}
+                    {% do assets.addJs('https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js',{'priority':100, 'group':'bottom'}) %}
                 {% endif %}
             {% endblock %}
             {{ assets.js('bottom') }}

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -128,7 +128,7 @@
                 {% endif %}
                 {% if page.header.google_prettify == "disabled" %}
                 {% elseif page.header.google_prettify == "enabled" or theme_config.google_prettify.enabled %}
-                    {% do assets.addJs('https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js',{'priority':100, 'group':'bottom'}) %}
+                    {% do assets.addJs('https://github.com/google/code-prettify',{'priority':100, 'group':'bottom'}) %}
                 {% endif %}
             {% endblock %}
             {{ assets.js('bottom') }}


### PR DESCRIPTION
The old URL was not working for me -- although the referenced file still exists, no syntax highlighting took place. I changed the URL according to the setup section [here](https://github.com/google/code-prettify).
